### PR TITLE
Remove indexes between runs to keep suite clean

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,13 @@ RSpec.configure do |c|
       example.run
     }
   end
+
+  c.after(:suite) do
+    indices = Algolia.client.list_indexes()['items'].sort_by { |index| index["primary"] || "" }
+    indices.each do |index|
+      Algolia.client.delete_index!(index['name'])
+    end
+  end
 end
 
 # avoid concurrent access to the same index

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,7 +36,7 @@ RSpec.configure do |c|
 end
 
 # A unique prefix for your test run in local or CI
-SAFE_INDEX_PREFIX = SecureRandom.hex(8).freeze
+SAFE_INDEX_PREFIX = "rails_#{SecureRandom.hex(8)}".freeze
 
 # avoid concurrent access to the same index in local or CI
 def safe_index_name(name)


### PR DESCRIPTION
1. Add secure random for true unique index names.
1. Add a rails specific prefix for easy identification.
1. Sort indices so we don't attempt to delete a replica or slave.
1. Filter created indexes by secure random for deleting.